### PR TITLE
Add MMIO register labels

### DIFF
--- a/GhidraNes/src/main/java/ghidranes/GhidraNesLoader.java
+++ b/GhidraNes/src/main/java/ghidranes/GhidraNesLoader.java
@@ -47,9 +47,10 @@ import ghidranes.errors.NesRomException;
 import ghidranes.errors.UnimplementedNesMapperException;
 import ghidranes.mappers.NesMapper;
 import ghidranes.util.MemoryBlockDescription;
+import ghidranes.util.NesMmio;
 
 /**
- * TODO: Provide class-level documentation that describes what this loader does.
+ * This loader parses an iNES ROM file and maps the PRG and CHR rom appropriately
  */
 public class GhidraNesLoader extends AbstractLibrarySupportLoader {
 
@@ -107,19 +108,19 @@ public class GhidraNesLoader extends AbstractLibrarySupportLoader {
 			Memory memory =  program.getMemory();
 
 			Address nmiAddress = addressSpace.getAddress(0xFFFA);
-			Symbol nmiSymbol = symbolTable.createLabel(addressSpace.getAddress(0xFFFA), "NMI", SourceType.IMPORTED);
+			Symbol nmiSymbol = symbolTable.createLabel(nmiAddress, "NMI", SourceType.IMPORTED);
 			nmiSymbol.setPinned(true);
 			nmiSymbol.setPrimary();
 			symbolTable.addExternalEntryPoint(nmiAddress);
 
 			Address resAddress = addressSpace.getAddress(0xFFFC);
-			Symbol resSymbol = symbolTable.createLabel(addressSpace.getAddress(0xFFFC), "RES", SourceType.IMPORTED);
+			Symbol resSymbol = symbolTable.createLabel(resAddress, "RES", SourceType.IMPORTED);
 			resSymbol.setPinned(true);
 			resSymbol.setPrimary();
 			symbolTable.addExternalEntryPoint(resAddress);
 
 			Address irqAddress = addressSpace.getAddress(0xFFFE);
-			Symbol irqSymbol = symbolTable.createLabel(addressSpace.getAddress(0xFFFE), "IRQ", SourceType.IMPORTED);
+			Symbol irqSymbol = symbolTable.createLabel(irqAddress, "IRQ", SourceType.IMPORTED);
 			irqSymbol.setPinned(true);
 			irqSymbol.setPrimary();
 			symbolTable.addExternalEntryPoint(irqAddress);
@@ -153,6 +154,44 @@ public class GhidraNesLoader extends AbstractLibrarySupportLoader {
 			irqTargetSymbol.setPrimary();
 			nmiTargetSymbol.setPrimary();
 			resTargetSymbol.setPrimary();
+
+			NesMmio []registers = {
+				new NesMmio(addressSpace, 0x2000, "PPUCTRL"),
+				new NesMmio(addressSpace, 0x2001, "PPUMASK"),
+				new NesMmio(addressSpace, 0x2002, "PPUSTATUS"),
+				new NesMmio(addressSpace, 0x2003, "OAMADDR"),
+				new NesMmio(addressSpace, 0x2004, "OAMDATA"),
+				new NesMmio(addressSpace, 0x2005, "PPUSCROLL"),
+				new NesMmio(addressSpace, 0x2006, "PPUADDR"),
+				new NesMmio(addressSpace, 0x2007, "PPUDATA"),
+				new NesMmio(addressSpace, 0x4000, "SQ1_VOL"),
+				new NesMmio(addressSpace, 0x4001, "SQ1_SWEEP"),
+				new NesMmio(addressSpace, 0x4002, "SQ1_LO"),
+				new NesMmio(addressSpace, 0x4003, "SQ1_HI"),
+				new NesMmio(addressSpace, 0x4004, "SQ2_VOL"),
+				new NesMmio(addressSpace, 0x4005, "SQ2_SWEEP"),
+				new NesMmio(addressSpace, 0x4006, "SQ2_LO"),
+				new NesMmio(addressSpace, 0x4007, "SQ2_HI"),
+				new NesMmio(addressSpace, 0x4008, "TRI_LINEAR"),
+				new NesMmio(addressSpace, 0x400a, "TRI_LO"),
+				new NesMmio(addressSpace, 0x400b, "TRI_HI"),
+				new NesMmio(addressSpace, 0x400c, "NOISE_VOL"),
+				new NesMmio(addressSpace, 0x400e, "NOISE_LO"),
+				new NesMmio(addressSpace, 0x400f, "NOISE_HI"),
+				new NesMmio(addressSpace, 0x4010, "DMC_FREQ"),
+				new NesMmio(addressSpace, 0x4011, "DMC_RAW"),
+				new NesMmio(addressSpace, 0x4012, "DMC_START"),
+				new NesMmio(addressSpace, 0x4013, "DMC_LEN"),
+				new NesMmio(addressSpace, 0x4014, "OAMDMA"),
+				new NesMmio(addressSpace, 0x4015, "SND_CHN"),
+				new NesMmio(addressSpace, 0x4016, "JOY1"),
+				new NesMmio(addressSpace, 0x4017, "JOY2"),
+			};
+			for (int i = 0; i < registers.length; i++) {
+				Symbol s = symbolTable.createLabel(registers[i].address, registers[i].name, SourceType.IMPORTED);
+				s.setPinned(true);
+			}
+
 		} catch (InvalidInputException | AddressOutOfBoundsException | MemoryAccessException e) {
 			throw new RuntimeException(e);
 		}

--- a/GhidraNes/src/main/java/ghidranes/NesRomHeader.java
+++ b/GhidraNes/src/main/java/ghidranes/NesRomHeader.java
@@ -80,16 +80,16 @@ public class NesRomHeader {
 		boolean flagPrgRamBit         = (flags10 & 0b0001_0000) != 0;
 //		boolean busConflictBit        = (flags10 & 0b0010_0000) != 0;
 
-		this.prgRomSizeBytes = prgRomSizeField * 16_384;
-		this.chrRomSizeBytes = chrRomSizeField * 8_192;
+		this.prgRomSizeBytes = prgRomSizeField * 0x4000;
+		this.chrRomSizeBytes = chrRomSizeField * 0x2000;
 		if (flagPrgRamBit) {
 			if (prgRamSizeField == 0) {
                 // When a ROM has the PRG RAM bit set but has a PRG RAM
                 // size of 0, then a fallback size of 8KB is used
-				this.prgRamSizeBytes = 8_192;
+				this.prgRamSizeBytes = 0x2000;
 			}
 			else {
-				this.prgRamSizeBytes = prgRamSizeField * 8_192;
+				this.prgRamSizeBytes = prgRamSizeField * 0x2000;
 			}
 		}
 		else {

--- a/GhidraNes/src/main/java/ghidranes/mappers/NromMapper.java
+++ b/GhidraNes/src/main/java/ghidranes/mappers/NromMapper.java
@@ -16,9 +16,9 @@ public class NromMapper extends NesMapper {
 	@Override
 	public void updateMemoryMapForRom(NesRom rom, Program program, TaskMonitor monitor) throws LockException, MemoryConflictException, AddressOverflowException, CancelledException, DuplicateNameException {
 		// TODO: Do we always want to include work RAM?
-		int workRamPermissions =
+		int sramPermissions =
 			MemoryBlockDescription.READ | MemoryBlockDescription.WRITE | MemoryBlockDescription.EXECUTE;
-		MemoryBlockDescription.uninitialized(0x6000, 0x2000, "WORK_RAM", workRamPermissions, false)
+		MemoryBlockDescription.uninitialized(0x6000, 0x2000, "SRAM", sramPermissions, false)
 			.create(program);
 
 		// TODO: Do we need all this? It appears no NROM games have anything besides 16K or 32K, so we will only ever need to create one mirror

--- a/GhidraNes/src/main/java/ghidranes/util/NesMmio.java
+++ b/GhidraNes/src/main/java/ghidranes/util/NesMmio.java
@@ -1,0 +1,13 @@
+package ghidranes.util;
+
+import ghidra.program.model.address.AddressSpace;
+import ghidra.program.model.address.Address;
+
+public class NesMmio {
+	public Address address;
+	public String name;
+	public NesMmio(AddressSpace addressSpace, int _address, String _name) {
+		address = addressSpace.getAddress(_address);
+		name = _name;
+	}
+}


### PR DESCRIPTION
I don't really know java at all, so I am not sure if you'd like this done another way.

Also, the NMI and other vectors could also use this mmio struct, but then the naming doesn't make sense, let me know if you'd like a renaming and to include the vectors in the list.

Compare against:

* https://www.nesdev.org/wiki/2A03
* https://www.nesdev.org/wiki/PPU_registers