### PR TITLE
Add support for mapper 2 (UxROM)

### DIFF
--- a/GhidraNes/src/main/java/ghidranes/mappers/NesMapper.java
+++ b/GhidraNes/src/main/java/ghidranes/mappers/NesMapper.java
@@ -19,6 +19,8 @@ public abstract class NesMapper {
 			return new NromMapper();
 		case 1:
 			return new MMC1Mapper();
+		case 2:
+			return new UxROMMapper();
 		case 7:
 			return new AxROMMapper();
 		case 19:

--- a/GhidraNes/src/main/java/ghidranes/mappers/UxROMMapper.java
+++ b/GhidraNes/src/main/java/ghidranes/mappers/UxROMMapper.java
@@ -1,0 +1,39 @@
+package ghidranes.mappers;
+
+import java.util.Arrays;
+
+import ghidra.framework.store.LockException;
+import ghidra.program.model.address.AddressOverflowException;
+import ghidra.program.model.listing.Program;
+import ghidra.program.model.mem.MemoryConflictException;
+import ghidra.util.exception.CancelledException;
+import ghidra.util.exception.DuplicateNameException;
+import ghidra.util.task.TaskMonitor;
+import ghidranes.NesRom;
+import ghidranes.util.MemoryBlockDescription;
+
+public class UxROMMapper extends NesMapper {
+    @Override
+    public void updateMemoryMapForRom(NesRom rom, Program program, TaskMonitor monitor) throws LockException, MemoryConflictException, AddressOverflowException, CancelledException, DuplicateNameException {
+
+        /* UxROM has switchable 16k PRG ROM banks mapped at 8000-FFFF.
+           The lower bank (fixed at 8000-BFFF) is typically the first bank, and 
+           the upper bank (C000-FFFF) is switchable. */
+        int bankCount = rom.prgRom.length / 0x4000;
+
+        // Load the fixed lower bank (first 16KB)
+        int lowerBankPermissions = MemoryBlockDescription.READ | MemoryBlockDescription.EXECUTE;
+        byte[] lowerBankBytes = Arrays.copyOfRange(rom.prgRom, 0, 0x4000);
+        MemoryBlockDescription.initialized(0x8000, 0x4000, "PRG Lower", lowerBankPermissions, lowerBankBytes, false, monitor)
+            .create(program);
+
+        // Load switchable upper banks
+        for (int bank = 1; bank < bankCount; bank++) {
+            int upperBankPermissions = MemoryBlockDescription.READ | MemoryBlockDescription.EXECUTE;
+
+            byte[] upperBankBytes = Arrays.copyOfRange(rom.prgRom, bank*0x4000, (bank+1)*0x4000);
+            MemoryBlockDescription.initialized(0xC000, 0x4000, "PRG Upper " + bank, upperBankPermissions, upperBankBytes, bank < (bankCount - 1), monitor)
+                .create(program);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Ghidra extension to support disassembling and analyzing NES ROMs.
 - Import NES ROMs in the iNES format. The following mappers are supported:
     - [NROM](https://www.nesdev.org/wiki/NROM) (mapper 0)
     - [MMC1](https://www.nesdev.org/wiki/MMC1) (mapper 1)
+    - [UxROM] (https://www.nesdev.org/wiki/UxROM) (mapper 2)
     - [AxROM](https://www.nesdev.org/wiki/AxROM) (mapper 7)
     - [Namco 129/163](https://www.nesdev.org/wiki/INES_Mapper_019) (mapper 19)
 


### PR DESCRIPTION
Honestly, 100% ChatGPT. I'm starting my adventure on NES disassembly right now with Mega Man and GhidraNes seemed like a great tool.

It compiled and worked on Ghidra, but I wouldn't be able to say if mapping is really correct or not

EDIT: tested with Ghidra 10.3.3