### PR TITLE
Add CHR ROM extraction for MMC3

### DIFF
--- a/GhidraNes/src/main/java/ghidranes/NesRom.java
+++ b/GhidraNes/src/main/java/ghidranes/NesRom.java
@@ -8,7 +8,7 @@ public class NesRom {
 	public NesRomHeader header;
 	byte[] trainerBytes;
 	public byte[] prgRom;
-	byte[] chrRom;
+	public byte[] chrRom;
 
 	public NesRom(NesRomHeader romHeader, InputStream bytes) throws NesRomEofException, IOException {
 		if (romHeader.hasTrainer) {

--- a/GhidraNes/src/main/java/ghidranes/mappers/MMC3Mapper.java
+++ b/GhidraNes/src/main/java/ghidranes/mappers/MMC3Mapper.java
@@ -62,6 +62,16 @@ public class MMC3Mapper extends NesMapper {
 		//CPU $E000-$FFFF: 8 KB PRG ROM bank, fixed to the last bank
 		MemoryBlockDescription.initialized(0xE000, 0x2000, "PRG" + bank + "_FIXED2", romPermissions, rombankBytes, false, monitor)
 			.create(program);
+		
+		// Make CHR ROM banks
+		if (rom.chrRom.length > 0) {
+			bank = 0;
+			for (bank = 0; (bank * 0x400) < rom.chrRom.length; bank ++) {
+				byte[] chrROMBankBytes = Arrays.copyOfRange(rom.chrRom, bank*0x400, (bank+1)*0x400);
+				MemoryBlockDescription.initialized(0x0, 0x400, "CHR" + bank, romPermissions, chrROMBankBytes, true, monitor)
+				.create(program);
+			}
+		}
 	}
 
 


### PR DESCRIPTION
I realized the game I'm decompiling (Earthbound Zero) has text data stored in the CHR ROM, so I added functionality to the MMC3 loader to extract the CHR ROM data also.  This is a little weird, since the CHR ROMs get mapped to the PPU, not the CPU, so they don't share the same address space as the PRG ROMs.  Additionally, each CHR ROM should really have 6 mirrors on the MMC3 to cover each possible PPU address range it could occupy, but that makes just an absurd number of memory regions (Earthbound Zero has 128x 1kB CHR ROMs, each of those would need 6 mirrors).

Because of those considerations I made the compromise of mapping each 1kB CHR ROM to 0x000-0x400 with no mirrors, though I don't think this is too bad since they only get mapped to the PPU anyway, so it's not like any code will be trying to pointing to the wrong address.  I confirmed that the numbering of the PRG ROMs and CHR ROMs matches how the NES numbers them by watching how my emulator was swapping banks.

While this is exactly what I need for my decompile and works well for my workflow, I realize it is a bit unusual.  Let me know if you think it's ok.