### PR TITLE
Update build to include Ghidra 11.3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         ghidra:
+          - "11.3.2"
           - "11.3.1"
           - "11.0.1"
           - "11.0"


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to build for Ghidra v11.3.2 (in addition to the other versions we already included)