### PR TITLE
Add support for mapper 16 and 66

### DIFF
--- a/GhidraNes/src/main/java/ghidranes/mappers/NesMapper.java
+++ b/GhidraNes/src/main/java/ghidranes/mappers/NesMapper.java
@@ -25,13 +25,13 @@ public abstract class NesMapper {
 		switch (mapperNum) {
 		case 0:
 			return new NromMapper();
-		case 1:
+		case 1,16:
 			return new MMC1Mapper();
 		case 2:
 			return new UxROMMapper();
 		case 4:
 			return new MMC3Mapper();
-		case 7:
+		case 7,66:
 			return new AxROMMapper();
 		case 10:
 			return new MMC4Mapper();

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ A Ghidra extension to support disassembling and analyzing NES ROMs.
 
 - Import NES ROMs in the iNES format. The following mappers are supported:
     - [NROM](https://www.nesdev.org/wiki/NROM) (mapper 0)
-    - [MMC1](https://www.nesdev.org/wiki/MMC1) (mapper 1)
+    - [MMC1](https://www.nesdev.org/wiki/MMC1) (mapper 1, also includes mapper 16)
     - [UxROM](https://www.nesdev.org/wiki/UxROM) (mapper 2)
     - [MMC3](https://www.nesdev.org/wiki/MMC3) (mapper 4)
-    - [AxROM](https://www.nesdev.org/wiki/AxROM) (mapper 7)
+    - [AxROM](https://www.nesdev.org/wiki/AxROM) (mapper 7, also includes mapper 66)
     - [MMC4](https://www.nesdev.org/wiki/MMC4) (mapper 10)
     - [Namco 129/163](https://www.nesdev.org/wiki/INES_Mapper_019) (mapper 19)
 


### PR DESCRIPTION
16 is basically a variant of MMC1 and 66 is a variant of AxROM, so this patch implements them by running the existing mapper handler for those mapper numbers.

Addresses issue #18.